### PR TITLE
Get rid of deprecation warnings in Rails 4.1

### DIFF
--- a/lib/active_model_otp.rb
+++ b/lib/active_model_otp.rb
@@ -1,5 +1,5 @@
 require "active_model"
-require "active_support/core_ext/class/attribute_accessors"
+require "active_support/core_ext/module/attribute_accessors"
 require "cgi"
 require "rotp"
 require "active_model/one_time_password"


### PR DESCRIPTION
The `cattr_*` method definitions have been moved into `active_support/core_ext/module/attribute_accessors`, so this fixes the require path.
