### PR TITLE
Avoid overriding predefined otp_column value when initializing resource

### DIFF
--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -5,7 +5,8 @@ module ActiveModel
     module ClassMethods
       def has_one_time_password(options = {})
 
-        cattr_accessor :otp_column_name, :otp_column
+        cattr_accessor  :otp_column_name
+        attr_accessible :otp_column
         self.otp_column_name = (options[:column_name] || "otp_secret_key").to_s
 
         include InstanceMethodsOnActivation


### PR DESCRIPTION
Currently there is no way of predefining a value for the otp_column as it is being overridden by the before_create callback.

Use case: admin user that creates other users, can only have access to the code when creating those users. If the code is generated on an after_create callback, it has to be visible on other views (besides resource.new) in order to have access to the code.
