### PR TITLE
Avoid overriding predefined otp_column value when initializing resource

### DIFF
--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -10,7 +10,7 @@ module ActiveModel
 
         include InstanceMethodsOnActivation
 
-        before_create { self.otp_column = ROTP::Base32.random_base32 }
+        before_create { self.otp_column ||= ROTP::Base32.random_base32 }
 
         if respond_to?(:attributes_protected_by_default)
           def self.attributes_protected_by_default #:nodoc:


### PR DESCRIPTION
Currently there is no way of predefining a value for the otp_column as it is being overridden by the before_create callback.

Use case: admin user that creates other users, can only have access to the code when creating those users. If the code is generated on an after_create callback, it has to be visible on other views (besides resource.new) in order to have access to the code.

NOTE: Did not know if gem should add attr_accessible for otp_column by default or if it has to be added manually on the resource with has_one_time_password.
