### PR TITLE
Adding options to provisioning uri, so we can include issuer

### DIFF
--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -49,9 +49,9 @@ module ActiveModel
         ROTP::TOTP.new(self.otp_column, {digits: self.otp_digits}).at(time, padding)
       end
 
-      def provisioning_uri(account = nil)
+      def provisioning_uri(account = nil,options={})
         account ||= self.email if self.respond_to?(:email)
-        ROTP::TOTP.new(self.otp_column).provisioning_uri(account)
+        ROTP::TOTP.new(self.otp_column,options).provisioning_uri(account)
       end
 
       def otp_column

--- a/test/one_time_password_test.rb
+++ b/test/one_time_password_test.rb
@@ -61,6 +61,13 @@ class OtpTest < MiniTest::Unit::TestCase
     assert_match %r{otpauth://totp/roberto@heapsource\.com\?secret=\w{16}}, @visitor.provisioning_uri
   end
 
+  def test_provisioning_uri_with_options
+    assert_match  %r{otpauth://totp/roberto@heapsource\.com\?issuer=Example&secret=\w{16}},@user.provisioning_uri(nil,issuer: "Example")
+    assert_match %r{otpauth://totp/roberto@heapsource\.com\?issuer=Example&secret=\w{16}}, @visitor.provisioning_uri(nil,issuer: "Example")
+    assert_match %r{otpauth://totp/roberto\?issuer=Example&secret=\w{16}}, @user.provisioning_uri("roberto", issuer: "Example")
+    assert_match %r{otpauth://totp/roberto\?issuer=Example&secret=\w{16}}, @visitor.provisioning_uri("roberto", issuer: "Example")
+  end
+
   def test_regenerate_otp
     secret = @user.otp_column
     @user.otp_regenerate_secret


### PR DESCRIPTION
This just adds an the ability to pass an options hash to  provisioning_uri, so we can add the issuer key, and pass it upstream to ROTP..  Allows us to Add the text at The top in Google Authenticator..  
