### PR TITLE
Fix SystemStackError with ActiveRecord

### DIFF
--- a/active_model_otp.gemspec
+++ b/active_model_otp.gemspec
@@ -21,7 +21,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activemodel"
   spec.add_dependency "rotp"
 
+  spec.add_development_dependency "activerecord"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.4.2"
+
+  if RUBY_PLATFORM == "java"
+    spec.add_development_dependency "activerecord-jdbcsqlite3-adapter"
+  else
+    spec.add_development_dependency "sqlite3"
+  end
 end

--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -96,11 +96,19 @@ module ActiveModel
       end
 
       def otp_counter
-        self.public_send(self.class.otp_counter_column_name)
+        if self.class.otp_counter_column_name != "otp_counter"
+          self.public_send(self.class.otp_counter_column_name)
+        else
+          super
+        end
       end
 
       def otp_counter=(attr)
-        self.public_send("#{self.class.otp_counter_column_name}=", attr)
+        if self.class.otp_counter_column_name != "otp_counter"
+          self.public_send("#{self.class.otp_counter_column_name}=", attr)
+        else
+          super
+        end
       end
     end
   end

--- a/test/models/activerecord_user.rb
+++ b/test/models/activerecord_user.rb
@@ -1,0 +1,3 @@
+class ActiverecordUser < ActiveRecord::Base
+  has_one_time_password counter_based: true
+end

--- a/test/one_time_password_test.rb
+++ b/test/one_time_password_test.rb
@@ -13,6 +13,10 @@ class OtpTest < MiniTest::Unit::TestCase
     @member = Member.new
     @member.email = nil
     @member.run_callbacks :create
+
+    @ar_user = ActiverecordUser.new
+    @ar_user.email = 'roberto@heapsource.com'
+    @ar_user.run_callbacks :create
   end
 
   def test_authenticate_with_otp
@@ -32,6 +36,17 @@ class OtpTest < MiniTest::Unit::TestCase
     assert @member.authenticate_otp(code)
     assert code == @member.otp_code
     assert code != @member.otp_code(auto_increment: true)
+  end
+
+  def test_counter_based_otp_active_record
+    code = @ar_user.otp_code
+    assert @ar_user.authenticate_otp(code)
+    assert @ar_user.authenticate_otp(code, auto_increment: true)
+    assert !@ar_user.authenticate_otp(code)
+    @ar_user.otp_counter -= 1
+    assert @ar_user.authenticate_otp(code)
+    assert code == @ar_user.otp_code
+    assert code != @ar_user.otp_code(auto_increment: true)
   end
 
   def test_authenticate_with_otp_when_drift_is_allowed

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -1,0 +1,11 @@
+ActiveRecord::Schema.define do
+  self.verbose = false
+
+  create_table :activerecord_users, force: true do |t|
+    t.string :key
+    t.string :email
+    t.integer :otp_counter
+    t.string :otp_secret_key
+    t.timestamps
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,5 +8,9 @@ require "rubygems"
 require "active_model_otp"
 require "minitest/autorun"
 require "minitest/unit"
+require "active_record"
+
+ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+load "#{ File.dirname(__FILE__) }/schema.rb"
 
 Dir["models/*.rb"].each {|file| require file }


### PR DESCRIPTION
Fixes #26 

If you use the default `otp_counter` column name,
InstanceMethodsOnActivation#otp_counter calls `otp_counter` resulting in
a stack overflow.