### PR TITLE
Update README to reflect that Twilio is used to send SMS rather than email

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ puts "Current code #{user.otp_code}"
 
 - [Generate QR code with rqrcode gem](https://github.com/heapsource/active_model_otp/wiki/Generate-QR-code-with-rqrcode-gem)
 - Generating QR Code with Google Charts API
-- [Sendind code via email with Twilio](https://github.com/heapsource/active_model_otp/wiki/Send-code-via-Twilio-SMS)
+- [Sending code via SMS with Twilio](https://github.com/heapsource/active_model_otp/wiki/Send-code-via-Twilio-SMS)
 - [Using with Mongoid](https://github.com/heapsource/active_model_otp/wiki/Using-with-Mongoid)
 
 ## Contributing


### PR DESCRIPTION
The README currently links to a wiki about sending codes via Twilio SMS, but the link text references "email" instead of "SMS". This PR fixes that. 