### PR TITLE
Fix otp_random_secret static method

### DIFF
--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -3,7 +3,6 @@ module ActiveModel
     extend ActiveSupport::Concern
 
     module ClassMethods
-
       def has_one_time_password(options = {})
         cattr_accessor :otp_column_name, :otp_counter_column_name
         class_attribute :otp_digits, :otp_counter_based
@@ -27,17 +26,17 @@ module ActiveModel
           end
         end
       end
-    end
 
-    module InstanceMethodsOnActivation
       # Defaults to 160 bit long secret
       # (meaning a 32 character long base32 secret)
       def otp_random_secret(length = 20)
         ROTP::Base32.random(length)
       end
+    end
 
+    module InstanceMethodsOnActivation
       def otp_regenerate_secret
-        self.otp_column = otp_random_secret
+        self.otp_column = self.class.otp_random_secret
       end
 
       def otp_regenerate_counter

--- a/test/one_time_password_test.rb
+++ b/test/one_time_password_test.rb
@@ -101,4 +101,8 @@ class OtpTest < MiniTest::Unit::TestCase
     refute_match(/otp_secret_key/, @user.to_json)
     refute_match(/otp_secret_key/, @user.to_xml)
   end
+
+  def test_otp_random_secret
+    assert_match /^.{32}$/, @user.class.otp_random_secret
+  end
 end


### PR DESCRIPTION
This PR fixes the following line in Readme:

```ruby
User.find_each { |user| user.update_attribute(:otp_secret_key, User.otp_random_secret) }
```

For now `@user.otp_random_secret` is instance method, not static