### PR TITLE
Add option for skipping secret generation

### DIFF
--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -5,20 +5,21 @@ module ActiveModel
     module ClassMethods
       def has_one_time_password(options = {})
         cattr_accessor :otp_column_name, :otp_counter_column_name
-        class_attribute :otp_digits, :otp_counter_based
+        class_attribute :otp_digits, :otp_counter_based, :skip_secret_generation
 
         self.otp_column_name = (options[:column_name] || "otp_secret_key").to_s
         self.otp_digits = options[:length] || 6
 
         self.otp_counter_based = (options[:counter_based] || false)
         self.otp_counter_column_name = (options[:counter_column_name] || "otp_counter").to_s
+        self.skip_secret_generation = options[:skip_secret_generation] || false
 
         include InstanceMethodsOnActivation
 
         before_create do
           self.otp_regenerate_secret if !otp_column
           self.otp_regenerate_counter if otp_counter_based && !otp_counter
-        end
+        end unless skip_secret_generation
 
         if respond_to?(:attributes_protected_by_default)
           def self.attributes_protected_by_default #:nodoc:

--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -5,21 +5,20 @@ module ActiveModel
     module ClassMethods
       def has_one_time_password(options = {})
         cattr_accessor :otp_column_name, :otp_counter_column_name
-        class_attribute :otp_digits, :otp_counter_based, :skip_secret_generation
+        class_attribute :otp_digits, :otp_counter_based
 
         self.otp_column_name = (options[:column_name] || "otp_secret_key").to_s
         self.otp_digits = options[:length] || 6
 
         self.otp_counter_based = (options[:counter_based] || false)
         self.otp_counter_column_name = (options[:counter_column_name] || "otp_counter").to_s
-        self.skip_secret_generation = options[:skip_secret_generation] || false
 
         include InstanceMethodsOnActivation
 
-        before_create do
+        before_create(options.slice(:if, :unless)) do
           self.otp_regenerate_secret if !otp_column
           self.otp_regenerate_counter if otp_counter_based && !otp_counter
-        end unless skip_secret_generation
+        end
 
         if respond_to?(:attributes_protected_by_default)
           def self.attributes_protected_by_default #:nodoc:

--- a/test/models/opt_in_two_factor.rb
+++ b/test/models/opt_in_two_factor.rb
@@ -8,5 +8,9 @@ class OptInTwoFactor
   define_model_callbacks :create
   attr_accessor :otp_secret_key, :email
 
-  has_one_time_password skip_secret_generation: true
+  has_one_time_password unless: :otp_opt_in?
+
+  def otp_opt_in?
+    true
+  end
 end

--- a/test/models/opt_in_two_factor.rb
+++ b/test/models/opt_in_two_factor.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class OptInTwoFactor
+  extend ActiveModel::Callbacks
+  include ActiveModel::Validations
+  include ActiveModel::OneTimePassword
+
+  define_model_callbacks :create
+  attr_accessor :otp_secret_key, :email
+
+  has_one_time_password skip_secret_generation: true
+end

--- a/test/one_time_password_test.rb
+++ b/test/one_time_password_test.rb
@@ -54,7 +54,7 @@ class OtpTest < MiniTest::Unit::TestCase
   end
 
   def test_opt_in_two_factor
-    assert @opt_in.otp_column == nil
+    assert @opt_in.otp_column.nil?
 
     @opt_in.otp_regenerate_secret
     code = @opt_in.otp_code

--- a/test/one_time_password_test.rb
+++ b/test/one_time_password_test.rb
@@ -17,6 +17,10 @@ class OtpTest < MiniTest::Unit::TestCase
     @ar_user = ActiverecordUser.new
     @ar_user.email = 'roberto@heapsource.com'
     @ar_user.run_callbacks :create
+
+    @opt_in = OptInTwoFactor.new
+    @opt_in.email = 'roberto@heapsource.com'
+    @opt_in.run_callbacks :create
   end
 
   def test_authenticate_with_otp
@@ -47,6 +51,14 @@ class OtpTest < MiniTest::Unit::TestCase
     assert @ar_user.authenticate_otp(code)
     assert code == @ar_user.otp_code
     assert code != @ar_user.otp_code(auto_increment: true)
+  end
+
+  def test_opt_in_two_factor
+    assert @opt_in.otp_column == nil
+
+    @opt_in.otp_regenerate_secret
+    code = @opt_in.otp_code
+    assert @opt_in.authenticate_otp(code)
   end
 
   def test_authenticate_with_otp_when_drift_is_allowed


### PR DESCRIPTION
On my app 2FA needs to be an opt-in feature. So I'd like to only generate the otp secret manually when users enable it. 