### PR TITLE
Not writing to database with auto_increment: true

### DIFF
--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -49,7 +49,7 @@ module ActiveModel
           result = hotp.verify(code, otp_counter)
           if result && options[:auto_increment]
             self.otp_counter += 1
-            save if respond_to?(:new_record?) && !new_record?
+            save if respond_to?(:changed?) && !new_record?
           end
           result
         else
@@ -66,7 +66,7 @@ module ActiveModel
         if otp_counter_based
           if options[:auto_increment]
             self.otp_counter += 1
-            save if respond_to?(:new_record?) && !new_record?
+            save if respond_to?(:changed?) && !new_record?
           end
           ROTP::HOTP.new(otp_column, digits: otp_digits).at(self.otp_counter)
         else


### PR DESCRIPTION
When using auto_increment it wouldn't save the model. It would continue as persisted and not new_record, but was flagged changed. When I had a different instance of the user the counter would never match, but always be zero.

If I only used the in-memory/cached user object then it would work just fine.
E.g.,
u = User.find(1)
u.otp_counter #=> 0
u.otp_code() #=> "226630"
u.otp_code(auto_increment: true) #=> "279079"
u.otp_counter #=> 1
u = User.find(1)
u.otp_counter #=> 0 (expected 1)