### PR TITLE
Add interval option

### DIFF
--- a/active_model_otp.gemspec
+++ b/active_model_otp.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  
+
   spec.required_ruby_version = ">= 2.3"
 
   spec.add_dependency "activemodel"
@@ -27,10 +27,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.4.2"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "activemodel-serializers-xml"
 
   if RUBY_PLATFORM == "java"
     spec.add_development_dependency "activerecord-jdbcsqlite3-adapter"
   else
-    spec.add_development_dependency "sqlite3", "~> 1.3.6"
+    spec.add_development_dependency "sqlite3", "~> 1.4"
   end
 end

--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -54,9 +54,11 @@ module ActiveModel
           end
           result
         else
-          totp = ROTP::TOTP.new(otp_column,
+          totp = ROTP::TOTP.new(
+            otp_column,
             digits: otp_digits,
-            interval: otp_interval)
+            interval: otp_interval
+          )
           if drift = options[:drift]
             totp.verify(code, drift_behind: drift)
           else
@@ -78,9 +80,11 @@ module ActiveModel
           else
             time = options
           end
-          ROTP::TOTP.new(otp_column,
+          ROTP::TOTP.new(
+            otp_column,
             digits: otp_digits,
-            interval: otp_interval).at(time)
+            interval: otp_interval
+          ).at(time)
         end
       end
 

--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -54,7 +54,9 @@ module ActiveModel
           end
           result
         else
-          totp = ROTP::TOTP.new(otp_column, digits: otp_digits, interval: otp_interval)
+          totp = ROTP::TOTP.new(otp_column,
+            digits: otp_digits,
+            interval: otp_interval)
           if drift = options[:drift]
             totp.verify(code, drift_behind: drift)
           else
@@ -76,7 +78,9 @@ module ActiveModel
           else
             time = options
           end
-          ROTP::TOTP.new(otp_column, digits: otp_digits, interval: otp_interval).at(time)
+          ROTP::TOTP.new(otp_column,
+            digits: otp_digits,
+            interval: otp_interval).at(time)
         end
       end
 

--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -5,13 +5,14 @@ module ActiveModel
     module ClassMethods
       def has_one_time_password(options = {})
         cattr_accessor :otp_column_name, :otp_counter_column_name
-        class_attribute :otp_digits, :otp_counter_based
+        class_attribute :otp_digits, :otp_counter_based, :otp_interval
 
         self.otp_column_name = (options[:column_name] || "otp_secret_key").to_s
         self.otp_digits = options[:length] || 6
 
         self.otp_counter_based = (options[:counter_based] || false)
         self.otp_counter_column_name = (options[:counter_column_name] || "otp_counter").to_s
+        self.otp_interval = options[:interval]
 
         include InstanceMethodsOnActivation
 
@@ -53,7 +54,7 @@ module ActiveModel
           end
           result
         else
-          totp = ROTP::TOTP.new(otp_column, digits: otp_digits)
+          totp = ROTP::TOTP.new(otp_column, digits: otp_digits, interval: otp_interval)
           if drift = options[:drift]
             totp.verify(code, drift_behind: drift)
           else
@@ -75,7 +76,7 @@ module ActiveModel
           else
             time = options
           end
-          ROTP::TOTP.new(otp_column, digits: otp_digits).at(time)
+          ROTP::TOTP.new(otp_column, digits: otp_digits, interval: otp_interval).at(time)
         end
       end
 

--- a/test/models/player.rb
+++ b/test/models/player.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Player
   extend ActiveModel::Callbacks
   include ActiveModel::Serializers::JSON

--- a/test/models/player.rb
+++ b/test/models/player.rb
@@ -1,0 +1,15 @@
+class Player
+  extend ActiveModel::Callbacks
+  include ActiveModel::Serializers::JSON
+  include ActiveModel::Serializers::Xml
+  include ActiveModel::Validations
+  include ActiveModel::OneTimePassword
+
+  define_model_callbacks :create
+  attr_accessor :otp_secret_key, :email
+
+  has_one_time_password interval: 2 # 2 seconds
+  def attributes
+    { "otp_secret_key" => otp_secret_key, "email" => email }
+  end
+end

--- a/test/models/player.rb
+++ b/test/models/player.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Player
   extend ActiveModel::Callbacks
   include ActiveModel::Serializers::JSON
@@ -10,6 +11,6 @@ class Player
 
   has_one_time_password interval: 2 # 2 seconds
   def attributes
-    { "otp_secret_key" => otp_secret_key, "email" => email }
+    { 'otp_secret_key' => otp_secret_key, 'email' => email }
   end
 end

--- a/test/one_time_password_test.rb
+++ b/test/one_time_password_test.rb
@@ -21,6 +21,10 @@ class OtpTest < MiniTest::Unit::TestCase
     @opt_in = OptInTwoFactor.new
     @opt_in.email = 'roberto@heapsource.com'
     @opt_in.run_callbacks :create
+
+    @player = Player.new
+    @player.email = '123'
+    @player.run_callbacks :create
   end
 
   def test_authenticate_with_otp
@@ -116,5 +120,12 @@ class OtpTest < MiniTest::Unit::TestCase
 
   def test_otp_random_secret
     assert_match /^.{32}$/, @user.class.otp_random_secret
+  end
+
+  def test_otp_interval
+    otp_code = @player.otp_code
+    2.times { assert_match(otp_code, @player.otp_code) }
+    sleep 2
+    refute_match(otp_code, @player.otp_code)
   end
 end


### PR DESCRIPTION
Hi !
1) [ROTP gem supports interval option](https://github.com/mdp/rotp/blob/aa0ff2e3c8956a0567d7cb0ee99a0b38b5463e49/lib/rotp/totp.rb#L9) => It will be awesome to support it in this gem too :nerd_face: 
2) There is a test error

```
/home/rusikf/.rvm/gems/ruby-2.6.4/gems/bundler-2.1.4/lib/bundler/rubygems_integration.rb:346:in `block (2 levels) in replace_gem': Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-1.3.13. Make s
ure all dependencies are added to Gemfile. (LoadError) 
``` 
The reason - in rails_6.0.gemfile dependency is 1.4 but in gemspec we have 1.3

`gemfiles/rails_6.0.gemfile:gem "sqlite3", "~> 1.4" `
That's why I upgraded sqlite to 1.4
+ there was a test error because of rails 6: => I added this gem
[`uninitialized constant ActiveModel::Serializers::Xml `](https://github.com/rails/rails/issues/24558)