### PR TITLE
Add counter value when triggering ROTP#provisioning_uri

### DIFF
--- a/active_model_otp.gemspec
+++ b/active_model_otp.gemspec
@@ -24,10 +24,19 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rotp", "~> 6.2.0"
 
   spec.add_development_dependency "activerecord"
-  spec.add_development_dependency "activemodel-serializers-xml"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.4.2"
   spec.add_development_dependency "appraisal"
+
+  Gem::Specification
+    .select { |dependency| dependency.name == "activemodel" }
+    .max_by(&:version).tap do |dependency|
+      major, = dependency.version.segments
+
+      if major >= 5
+        spec.add_development_dependency "activemodel-serializers-xml"
+      end
+    end
 
   if RUBY_PLATFORM == "java"
     spec.add_development_dependency "activerecord-jdbcsqlite3-adapter"

--- a/active_model_otp.gemspec
+++ b/active_model_otp.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rotp", "~> 6.2.0"
 
   spec.add_development_dependency "activerecord"
+  spec.add_development_dependency "activemodel-serializers-xml"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.4.2"
   spec.add_development_dependency "appraisal"

--- a/active_model_otp.gemspec
+++ b/active_model_otp.gemspec
@@ -28,16 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.4.2"
   spec.add_development_dependency "appraisal"
 
-  Gem::Specification
-    .select { |dependency| dependency.name == "activemodel" }
-    .max_by(&:version).tap do |dependency|
-      major, = dependency.version.segments
-
-      if major >= 5
-        spec.add_development_dependency "activemodel-serializers-xml"
-      end
-    end
-
   if RUBY_PLATFORM == "java"
     spec.add_development_dependency "activerecord-jdbcsqlite3-adapter"
   else

--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -97,9 +97,13 @@ module ActiveModel
         account ||= ""
 
         if otp_counter_based
-          ROTP::HOTP.new(otp_column, options).provisioning_uri(account, self.otp_counter)
+          ROTP::HOTP
+            .new(otp_column, options)
+            .provisioning_uri(account, self.otp_counter)
         else
-          ROTP::TOTP.new(otp_column, options).provisioning_uri(account)
+          ROTP::TOTP
+            .new(otp_column, options)
+            .provisioning_uri(account)
         end
       end
 

--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -97,7 +97,7 @@ module ActiveModel
         account ||= ""
 
         if otp_counter_based
-          ROTP::HOTP.new(otp_column, options).provisioning_uri(account)
+          ROTP::HOTP.new(otp_column, options).provisioning_uri(account, self.otp_counter)
         else
           ROTP::TOTP.new(otp_column, options).provisioning_uri(account)
         end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -8,6 +8,7 @@ class User
   attr_accessor :otp_secret_key, :otp_backup_codes, :email
 
   has_one_time_password one_time_backup_codes: true
+
   def attributes
     { "otp_secret_key" => otp_secret_key, "email" => email }
   end

--- a/test/one_time_password_test.rb
+++ b/test/one_time_password_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class OtpTest < MiniTest::Test
   def setup
@@ -100,28 +102,51 @@ class OtpTest < MiniTest::Test
   end
 
   def test_provisioning_uri_with_provided_account
-    assert_match %r{^otpauth://totp/roberto\?secret=\w{32}$}, @user.provisioning_uri("roberto")
-    assert_match %r{^otpauth://totp/roberto\?secret=\w{32}$}, @visitor.provisioning_uri("roberto")
-    assert_match %r{^otpauth://hotp/roberto\?secret=\w{32}&counter=1$}, @member.provisioning_uri("roberto")
+    totp = %r{^otpauth://totp/roberto\?secret=\w{32}$}
+    hotp = %r{^otpauth://hotp/roberto\?secret=\w{32}&counter=1$}
+
+    assert_match totp, @user.provisioning_uri('roberto')
+    assert_match totp, @visitor.provisioning_uri('roberto')
+    assert_match hotp, @member.provisioning_uri('roberto')
   end
 
   def test_provisioning_uri_with_email_field
-    assert_match %r{^otpauth://totp/roberto%40heapsource\.com\?secret=\w{32}$}, @user.provisioning_uri
-    assert_match %r{^otpauth://totp/roberto%40heapsource\.com\?secret=\w{32}$}, @visitor.provisioning_uri
-    assert_match %r{^otpauth://hotp/\?secret=\w{32}&counter=1$}, @member.provisioning_uri
+    totp = %r{^otpauth://totp/roberto%40heapsource\.com\?secret=\w{32}$}
+    hotp = %r{^otpauth://hotp/\?secret=\w{32}&counter=1$}
+
+    assert_match totp, @user.provisioning_uri
+    assert_match totp, @visitor.provisioning_uri
+    assert_match hotp, @member.provisioning_uri
   end
 
   def test_provisioning_uri_with_options
-    assert_match %r{^otpauth://totp/Example\:roberto%40heapsource\.com\?secret=\w{32}&issuer=Example$}, @user.provisioning_uri(nil, issuer: "Example")
-    assert_match %r{^otpauth://totp/Example\:roberto%40heapsource\.com\?secret=\w{32}&issuer=Example$}, @visitor.provisioning_uri(nil, issuer: "Example")
-    assert_match %r{^otpauth://totp/Example\:roberto\?secret=\w{32}&issuer=Example$}, @user.provisioning_uri("roberto", issuer: "Example")
-    assert_match %r{^otpauth://totp/Example\:roberto\?secret=\w{32}&issuer=Example$}, @visitor.provisioning_uri("roberto", issuer: "Example")
+    account = %r{
+      ^otpauth://totp/Example\:roberto\?secret=\w{32}&issuer=Example$
+    }x
+
+    email = %r{
+      ^otpauth://totp/Example\:roberto%40heapsource\.com\?secret=\w{32}
+      &issuer=Example$
+    }x
+
+    assert_match(
+      account, @user.provisioning_uri('roberto', issuer: 'Example')
+    )
+
+    assert_match(
+      account, @visitor.provisioning_uri('roberto', issuer: 'Example')
+    )
+
+    assert_match email, @user.provisioning_uri(nil, issuer: 'Example')
+    assert_match email, @visitor.provisioning_uri(nil, issuer: 'Example')
   end
 
   def test_provisioning_uri_with_incremented_counter
     2.times { @member.otp_code(auto_increment: true) }
 
-    assert_match %r{^otpauth://hotp/\?secret=\w{32}&counter=3$}, @member.provisioning_uri
+    hotp = %r{^otpauth://hotp/\?secret=\w{32}&counter=3$}
+
+    assert_match hotp, @member.provisioning_uri
   end
 
   def test_regenerate_otp

--- a/test/one_time_password_test.rb
+++ b/test/one_time_password_test.rb
@@ -102,13 +102,13 @@ class OtpTest < MiniTest::Test
   def test_provisioning_uri_with_provided_account
     assert_match %r{^otpauth://totp/roberto\?secret=\w{32}$}, @user.provisioning_uri("roberto")
     assert_match %r{^otpauth://totp/roberto\?secret=\w{32}$}, @visitor.provisioning_uri("roberto")
-    assert_match %r{^otpauth://hotp/roberto\?secret=\w{32}&counter=0$}, @member.provisioning_uri("roberto")
+    assert_match %r{^otpauth://hotp/roberto\?secret=\w{32}&counter=1$}, @member.provisioning_uri("roberto")
   end
 
   def test_provisioning_uri_with_email_field
     assert_match %r{^otpauth://totp/roberto%40heapsource\.com\?secret=\w{32}$}, @user.provisioning_uri
     assert_match %r{^otpauth://totp/roberto%40heapsource\.com\?secret=\w{32}$}, @visitor.provisioning_uri
-    assert_match %r{^otpauth://hotp/\?secret=\w{32}&counter=0$}, @member.provisioning_uri
+    assert_match %r{^otpauth://hotp/\?secret=\w{32}&counter=1$}, @member.provisioning_uri
   end
 
   def test_provisioning_uri_with_options
@@ -116,6 +116,12 @@ class OtpTest < MiniTest::Test
     assert_match %r{^otpauth://totp/Example\:roberto%40heapsource\.com\?secret=\w{32}&issuer=Example$}, @visitor.provisioning_uri(nil, issuer: "Example")
     assert_match %r{^otpauth://totp/Example\:roberto\?secret=\w{32}&issuer=Example$}, @user.provisioning_uri("roberto", issuer: "Example")
     assert_match %r{^otpauth://totp/Example\:roberto\?secret=\w{32}&issuer=Example$}, @visitor.provisioning_uri("roberto", issuer: "Example")
+  end
+
+  def test_provisioning_uri_with_incremented_counter
+    2.times { @member.otp_code(auto_increment: true) }
+
+    assert_match %r{^otpauth://hotp/\?secret=\w{32}&counter=3$}, @member.provisioning_uri
   end
 
   def test_regenerate_otp


### PR DESCRIPTION
Related to: https://github.com/heapsource/active_model_otp/issues/74

## Changes

- Add `self.otp_counter` when calling `ROTP#provisioning_uri` in order to have it on the final URI

## Concerns

- Even though it seems somethings that never caused issues, reading through the [RFC-4226](https://tools.ietf.org/html/rfc4226#section-7.4) I noticed some requirements on keeping the counter synchronized between server/client, please, let me know your thoughts regarding that.

Note.: **_Taking a look at the source it doesn't seem we're caring about the `houndci-bot` for line length metrics. Did we enable `houndci-bot` recently?_**