### PR TITLE
Add support for ruby 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Dependencies
 
-* [ROTP](https://github.com/mdp/rotp) 5.0 or higher
+* [ROTP](https://github.com/mdp/rotp) 6.2.0 or higher
 * Ruby 2.3 or greater
 
 ## Installation

--- a/active_model_otp.gemspec
+++ b/active_model_otp.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   if RUBY_PLATFORM == "java"
     spec.add_development_dependency "activerecord-jdbcsqlite3-adapter"
   else
-    spec.add_development_dependency "sqlite3", "~> 1.4.2"
+    spec.add_development_dependency "sqlite3", "~> 1.3.6"
   end
 end

--- a/active_model_otp.gemspec
+++ b/active_model_otp.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  
+
   spec.required_ruby_version = ">= 2.3"
 
   spec.add_dependency "activemodel"
-  spec.add_dependency "rotp", "~> 5.0.0"
+  spec.add_dependency "rotp", "~> 6.2.0"
 
   spec.add_development_dependency "activerecord"
   spec.add_development_dependency "rake"
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   if RUBY_PLATFORM == "java"
     spec.add_development_dependency "activerecord-jdbcsqlite3-adapter"
   else
-    spec.add_development_dependency "sqlite3", "~> 1.3.6"
+    spec.add_development_dependency "sqlite3", "~> 1.4.2"
   end
 end

--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -15,7 +15,7 @@ module ActiveModel
 
         include InstanceMethodsOnActivation
 
-        before_create(options.slice(:if, :unless)) do
+        before_create(**options.slice(:if, :unless)) do
           self.otp_regenerate_secret if !otp_column
           self.otp_regenerate_counter if otp_counter_based && !otp_counter
         end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -1,7 +1,6 @@
 class User
   extend ActiveModel::Callbacks
   include ActiveModel::Serializers::JSON
-  include ActiveModel::Serializers::Xml
   include ActiveModel::Validations
   include ActiveModel::OneTimePassword
 

--- a/test/one_time_password_test.rb
+++ b/test/one_time_password_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class OtpTest < MiniTest::Unit::TestCase
+class OtpTest < MiniTest::Test
   def setup
     @user = User.new
     @user.email = 'roberto@heapsource.com'
@@ -91,14 +91,14 @@ class OtpTest < MiniTest::Unit::TestCase
   end
 
   def test_provisioning_uri_with_email_field
-    assert_match %r{^otpauth://totp/roberto@heapsource\.com\?secret=\w{32}$}, @user.provisioning_uri
-    assert_match %r{^otpauth://totp/roberto@heapsource\.com\?secret=\w{32}$}, @visitor.provisioning_uri
+    assert_match %r{^otpauth://totp/roberto%40heapsource\.com\?secret=\w{32}$}, @user.provisioning_uri
+    assert_match %r{^otpauth://totp/roberto%40heapsource\.com\?secret=\w{32}$}, @visitor.provisioning_uri
     assert_match %r{^otpauth://hotp/\?secret=\w{32}&counter=0$}, @member.provisioning_uri
   end
 
   def test_provisioning_uri_with_options
-    assert_match %r{^otpauth://totp/Example\:roberto@heapsource\.com\?secret=\w{32}&issuer=Example$}, @user.provisioning_uri(nil, issuer: "Example")
-    assert_match %r{^otpauth://totp/Example\:roberto@heapsource\.com\?secret=\w{32}&issuer=Example$}, @visitor.provisioning_uri(nil, issuer: "Example")
+    assert_match %r{^otpauth://totp/Example\:roberto%40heapsource\.com\?secret=\w{32}&issuer=Example$}, @user.provisioning_uri(nil, issuer: "Example")
+    assert_match %r{^otpauth://totp/Example\:roberto%40heapsource\.com\?secret=\w{32}&issuer=Example$}, @visitor.provisioning_uri(nil, issuer: "Example")
     assert_match %r{^otpauth://totp/Example\:roberto\?secret=\w{32}&issuer=Example$}, @user.provisioning_uri("roberto", issuer: "Example")
     assert_match %r{^otpauth://totp/Example\:roberto\?secret=\w{32}&issuer=Example$}, @visitor.provisioning_uri("roberto", issuer: "Example")
   end
@@ -111,10 +111,9 @@ class OtpTest < MiniTest::Unit::TestCase
 
   def test_hide_secret_key_in_serialize
     refute_match(/otp_secret_key/, @user.to_json)
-    refute_match(/otp_secret_key/, @user.to_xml)
   end
 
   def test_otp_random_secret
-    assert_match /^.{32}$/, @user.class.otp_random_secret
+    assert_match(/^.{32}$/, @user.class.otp_random_secret)
   end
 end


### PR DESCRIPTION
Updated `rotp` with ruby 3.0 support, made small fix in `active_model_otp`, to support ruby 3.0