### PR TITLE
Github actions for publish to rubygems

### DIFF
--- a/.github/workflows/publish_to_rubygems.yml
+++ b/.github/workflows/publish_to_rubygems.yml
@@ -1,0 +1,31 @@
+name: Publish to Rubygems
+
+on:
+  workflow_dispatch:
+  #release:
+  #  types: [created]
+
+jobs:
+  publish-to-rubygems:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Publish to Rubygems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"


### PR DESCRIPTION
@robertomiranda I created a Github Actions in order to release versions to rubygems automatically when we create a new release in Github.

It is not working yet, because it is required to create a new secret in repo settings with name ""