### PR TITLE
After feature for TOTP to prevent code reuse

### DIFF
--- a/test/models/after_user.rb
+++ b/test/models/after_user.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AfterUser < ActiveRecord::Base
+  has_one_time_password after_column_name: :last_otp_at
+end

--- a/test/one_time_password_test.rb
+++ b/test/one_time_password_test.rb
@@ -23,6 +23,10 @@ class OtpTest < MiniTest::Test
     @opt_in = OptInTwoFactor.new
     @opt_in.email = 'roberto@heapsource.com'
     @opt_in.run_callbacks :create
+
+    @after_user = AfterUser.new
+    @after_user.email = 'roberto@heapsource.com'
+    @after_user.run_callbacks :create
   end
 
   def test_authenticate_with_otp
@@ -86,6 +90,18 @@ class OtpTest < MiniTest::Test
 
     code = @visitor.otp_code(Time.now - 30)
     assert_equal true, @visitor.authenticate_otp(code, drift: 60)
+  end
+
+  def test_authenticate_with_otp_when_after_is_allowed
+    code = @user.otp_code
+    assert_equal true, @user.authenticate_otp(code)
+    assert_equal true, @user.authenticate_otp(code)
+
+    code = @after_user.otp_code
+    assert_equal true, @after_user.authenticate_otp(code)
+    assert_equal false, @after_user.authenticate_otp(code)
+    assert_equal false, @after_user.authenticate_otp('1111111')
+    assert_equal false, @after_user.authenticate_otp(code)
   end
 
   def test_authenticate_with_backup_code

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -24,4 +24,13 @@ ActiveRecord::Schema.define do
     t.string :otp_secret_key
     t.timestamps
   end
+
+  create_table :after_users, force: true do |t|
+    t.string :key
+    t.string :email
+    t.integer :otp_counter
+    t.string :otp_secret_key
+    t.integer :last_otp_at
+    t.timestamps
+  end
 end


### PR DESCRIPTION
It is useful to be able to prevent the code reuse on OTP, specially when sending the code via SMS, which requires the extension of the time the code will be valid by using `drift`. 
 
ROTP reference:
https://github.com/mdp/rotp/blob/2be11551ac4982670d526ceef4a5db985d0f626a/README.md#preventing-reuse-of-time-based-otps