### PR TITLE
Update checkout action version, quote 3.0

### DIFF
--- a/.github/workflows/active_model_otp.yml
+++ b/.github/workflows/active_model_otp.yml
@@ -13,37 +13,37 @@ jobs:
     strategy:
       matrix:
         gemfile: [rails_4.2, rails_5.0, rails_5.1, rails_5.2, rails_6.0, rails_6.1, rails_7.0]
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2]
         exclude:
           - { gemfile: rails_4.2, ruby-version: 2.5 }
           - { gemfile: rails_4.2, ruby-version: 2.6 }
           - { gemfile: rails_4.2, ruby-version: 2.7 }
-          - { gemfile: rails_4.2, ruby-version: 3.0 }
+          - { gemfile: rails_4.2, ruby-version: '3.0' }
           - { gemfile: rails_4.2, ruby-version: 3.1 }
           - { gemfile: rails_4.2, ruby-version: 3.2 }
           - { gemfile: rails_5.0, ruby-version: 2.5 }
           - { gemfile: rails_5.0, ruby-version: 2.6 }
           - { gemfile: rails_5.0, ruby-version: 2.7 }
-          - { gemfile: rails_5.0, ruby-version: 3.0 }
+          - { gemfile: rails_5.0, ruby-version: '3.0' }
           - { gemfile: rails_5.0, ruby-version: 3.1 }
           - { gemfile: rails_5.0, ruby-version: 3.2 }
           - { gemfile: rails_5.1, ruby-version: 2.6 }
           - { gemfile: rails_5.1, ruby-version: 2.7 }
-          - { gemfile: rails_5.1, ruby-version: 3.0 }
+          - { gemfile: rails_5.1, ruby-version: '3.0' }
           - { gemfile: rails_5.1, ruby-version: 3.1 }
           - { gemfile: rails_5.1, ruby-version: 3.2 }
           - { gemfile: rails_5.2, ruby-version: 2.7 }
-          - { gemfile: rails_5.2, ruby-version: 3.0 }
+          - { gemfile: rails_5.2, ruby-version: '3.0' }
           - { gemfile: rails_5.2, ruby-version: 3.1 }
           - { gemfile: rails_5.2, ruby-version: 3.2 }
           - { gemfile: rails_6.0, ruby-version: 2.3 }
           - { gemfile: rails_6.0, ruby-version: 2.4 }
-          - { gemfile: rails_6.0, ruby-version: 3.0 }
+          - { gemfile: rails_6.0, ruby-version: '3.0' }
           - { gemfile: rails_6.0, ruby-version: 3.1 }
           - { gemfile: rails_6.0, ruby-version: 3.2 }
           - { gemfile: rails_6.1, ruby-version: 2.3 }
           - { gemfile: rails_6.1, ruby-version: 2.4 }
-          - { gemfile: rails_6.1, ruby-version: 3.0 }
+          - { gemfile: rails_6.1, ruby-version: '3.0' }
           - { gemfile: rails_6.1, ruby-version: 3.1 }
           - { gemfile: rails_6.1, ruby-version: 3.2 }
           - { gemfile: rails_7.0, ruby-version: 2.3 }
@@ -55,15 +55,13 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true
 
       - name: Run tests with Ruby ${{ matrix.ruby-version }} and Gemfile ${{ matrix.gemfile }}
         run: bundle exec rake


### PR DESCRIPTION
This PR makes 3 changes:

1. Updates the checkout version to v3 so the workflow can continue to run after Node v12 stops being supported
2. Quotes 3.0 so that it isn't truncated
3. Switches to using the bundler-cache in the ruby-setup action

Runs green on my fork.