### PR TITLE
Update rotp to 6.3.0 to fix CVE-2024-28862 

### DIFF
--- a/active_model_otp.gemspec
+++ b/active_model_otp.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3"
 
   spec.add_dependency "activemodel"
-  spec.add_dependency "rotp", "~> 6.2.0"
+  spec.add_dependency "rotp", "~> 6.3.0"
 
   spec.add_development_dependency "activerecord"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
There is a CVE reported on rotp to 6.2.1 and 6.2.2
The fix is to update rotp to >= 6.3.0

Current gemspec prevents the update   spec.add_dependency "rotp", "~> 6.2.0"

```
ruby-advisory-db:
  advisories:	882 advisories
  last updated:	2024-03-18 19:03:51 -0700
  commit:	35ca69bb256418b4cec81327e659ed6c0257d25b
Name: rotp
Version: 6.2.2
CVE: CVE-2024-28862
GHSA: GHSA-x2h8-qmj4-g62f
Criticality: Medium
URL: https://github.com/mdp/rotp/security/advisories/GHSA-x2h8-qmj4-g62f
Title: ROTP 6.2.2 and 6.2.1 has 0666 permissions for the .rb files.
Solution: upgrade to '>= 6.3.0'
```
