### PR TITLE
Fix for Rails 8.0.0

### DIFF
--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -114,7 +114,7 @@ module ActiveModel
       end
 
       def serializable_hash(options = nil)
-        options ||= {}
+        options = options ? options.dup : {}
         options[:except] = Array(options[:except])
         options[:except] << self.class.otp_column_name
 


### PR DESCRIPTION
Original code doesnt work well with Rails 8.0.0

For example:
in ruby console: User.all.to_json(only: [:id, :name])
Returns error  can't modify frozen Hash: {:only=>[:id, :name]} (FrozenError)

This PR will fix it.